### PR TITLE
Update bunny-mock.gemspec

### DIFF
--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -1,7 +1,6 @@
 #!/usr/bin/env gem build
 # encoding: utf-8
 
-require 'base64'
 require File.expand_path("../lib/bunny_mock/version", __FILE__)
 
 Gem::Specification.new do |s|
@@ -9,7 +8,6 @@ Gem::Specification.new do |s|
   s.version     = BunnyMock::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Andrew Rempe']
-  s.email       = [Base64.decode64('YW5kcmV3cmVtcGVAZ21haWwuY29t\n')]
   s.summary     = 'Mocking for the popular Bunny client for RabbitMQ'
   s.description = 'Easy to use mocking for testing the Bunny client for RabbitMQ'
   s.license     = 'MIT'


### PR DESCRIPTION
Starting with Ruby 3.4, many parts of the standard library (like base64, csv, set, etc.) have been split into separate gems